### PR TITLE
Change: make CIP-30/CIP-8 distinction more clear

### DIFF
--- a/app/api/verify/route.ts
+++ b/app/api/verify/route.ts
@@ -472,7 +472,7 @@ async function performVerification(
           isPrefixAppended,
           error,
           signatureFormat: isCoseFormat ? "COSE_Sign1" : "Raw",
-          signatureStandard: isCoseFormat ? "CIP-0030" : "CIP-0008",
+          signatureStandard: isCoseFormat ? "CIP-0030 version of CIP-0008" : "CIP-0008",
           messageHex,
           cleanPublicKey,
         };
@@ -508,7 +508,7 @@ async function performVerification(
     isPrefixAppended,
     error,
     signatureFormat: isCoseFormat ? "COSE_Sign1" : "Raw",
-    signatureStandard: isCoseFormat ? "CIP-0030" : "CIP-0008",
+    signatureStandard: isCoseFormat ? "CIP-0030 version of CIP-0008" : "CIP-0008",
     messageHex,
     cleanPublicKey,
   };
@@ -556,7 +556,7 @@ export async function POST(request: Request) {
     const valid = result.isCip8Verified || result.isCip30Verified;
     const signatureStandard =
       result.signatureStandard ||
-      (result.isCip30Verified ? "CIP-0030" : "CIP-0008");
+      (result.isCip30Verified ? "CIP-0030 version of CIP-0008" : "CIP-0008");
 
     return NextResponse.json({
       valid,

--- a/components/VerificationExample.js
+++ b/components/VerificationExample.js
@@ -35,7 +35,7 @@ const InformationSection = ({ fillCIP0008Example, fillCIP0030Example }) => {
         <h1 className="mt-4 text-sm font-normal mb-6 text-cf-blue-900 text-justify">
           This tool verifies signed messages for Cardano public keys in the
           browser. It can also verify the authors' signatures of Cardano
-          Governance Action proposals.{" "}
+          governance metadata.{" "}
           <span
             className="text-blue-500 cursor-pointer text-sm font-normal"
             onClick={() => setShowMoreText(!showMoreText)}
@@ -69,7 +69,7 @@ const InformationSection = ({ fillCIP0008Example, fillCIP0030Example }) => {
 
             <p className="text-sm text-cf-blue-900 text-justify mx-3">
               Signing messages on Cardano can be used to prove ownership of an
-              address(e.g. as alternative to a
+              address (e.g. as alternative to a
               <a
                 className="text-blue-500"
                 href="https://www.21analytics.ch/what-is-a-satoshi-test/"
@@ -92,7 +92,7 @@ const InformationSection = ({ fillCIP0008Example, fillCIP0030Example }) => {
                 {" "}
                 CIP-0008{" "}
               </a>
-              ,
+              (including the
               <a
                 className="text-blue-500"
                 href="https://cips.cardano.org/cip/CIP-0030"
@@ -102,6 +102,7 @@ const InformationSection = ({ fillCIP0008Example, fillCIP0030Example }) => {
                 {" "}
                 CIP-0030{" "}
               </a>
+              implementation)
               and
               <a
                 className="text-blue-500"
@@ -110,10 +111,9 @@ const InformationSection = ({ fillCIP0008Example, fillCIP0030Example }) => {
                 rel="noopener noreferrer"
               >
                 {" "}
-                CIP-0100{" "}
+                CIP-0100
               </a>
-              , given a public key, e.g. of a Cardano address and the signature
-              of the message.
+              , given a public key, the message and the signature.
             </p>
             <div className="flex justify-center gap-4 text-sm mt-2">
               <span className="text-cf-blue-800">Try it Out:</span>


### PR DESCRIPTION
## Checklist

- [x] I have run `npm run build` after adding my changes **without getting any errors**. 

## Changes

- Changed: labelling of 'CIP-0030' signatures to be 'CIP-0030 version of CIP-0008'

<img width="804" height="111" alt="image" src="https://github.com/user-attachments/assets/b4333548-e5cf-484c-b99b-44263b9e5293" />

- Changed: learn more text to state that CIP-0030 is an implementation of CIP-0008

<img width="705" height="209" alt="image" src="https://github.com/user-attachments/assets/eb3a8608-ab8c-45d8-9db6-41b3974c7e3d" />


## Motivation

I have found it confusing that the site labels CIP-8 signed messages produced via CIP-30 methods, as CIP-30 signed messages.
and this is a really handy tool, so wanted to contribute back 💪
